### PR TITLE
build: support dual-build with node-gyp and node-waf

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,11 @@
+{
+  'targets': [
+    {
+      'target_name': 'kstat',
+      'sources': [ 'kstat.cc' ],
+      'libraries': [ '-lkstat' ],
+      'cflags_cc': [ '-Wno-write-strings' ],
+      'cflags_cc!': [ '-fno-exceptions' ],
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,4 @@
 	"author":	"Joyent (joyent.com)",
 	"engines":	{ "node": ">=0.6" },
 	"main":		"build/Release/kstat",
-	"scripts": {
-	    "install": "node-waf configure build"
-	}
 }


### PR DESCRIPTION
Now newer versions of npm that include node-gyp will use that to build,
and older versions of npm will use node-waf to build.

Win-win!
