### PR TITLE
Make kstat build/work on node 0.10

### DIFF
--- a/kstat.cc
+++ b/kstat.cc
@@ -389,3 +389,5 @@ init (Handle<Object> target)
 {
 	KStatReader::Initialize(target);
 }
+
+NODE_MODULE(kstat, init);


### PR DESCRIPTION
With 0.10, node-gyp requires this notion of `NODE_MODULE`, else you get unresolved symbols at runtime.  This whopping one-line change will allow kstat to work in manta, amongst every other place that node 0.10 is default.  When merged, you should publish to npm with  a new major version such that 0.8 behavior is not altered.
