### PR TITLE
TRITON-2464 node-kstat leaks nvlists

### DIFF
--- a/addon.cc
+++ b/addon.cc
@@ -83,6 +83,7 @@ KStat::parse_options(const Napi::CallbackInfo& info)
 			Napi::TypeError::New(env,
 			    "illegal kstat specifier (expected string)")
 			    .ThrowAsJavaScriptException();
+			nvlist_free(nvl);
 			return (NULL);
 		}
 		nvlist_add_string(nvl, "class",
@@ -94,6 +95,7 @@ KStat::parse_options(const Napi::CallbackInfo& info)
 			Napi::TypeError::New(env,
 			    "illegal kstat specifier (expected string)")
 			    .ThrowAsJavaScriptException();
+			nvlist_free(nvl);
 			return (NULL);
 		}
 		nvlist_add_string(nvl, "name",
@@ -105,6 +107,7 @@ KStat::parse_options(const Napi::CallbackInfo& info)
 			Napi::TypeError::New(env,
 			    "illegal kstat specifier (expected string)")
 			    .ThrowAsJavaScriptException();
+			nvlist_free(nvl);
 			return (NULL);
 		}
 		nvlist_add_string(nvl, "module",
@@ -116,6 +119,7 @@ KStat::parse_options(const Napi::CallbackInfo& info)
 			Napi::TypeError::New(env,
 			    "illegal kstat specifier (expected double)")
 			    .ThrowAsJavaScriptException();
+			nvlist_free(nvl);
 			return (NULL);
 		}
 		nvlist_add_double(nvl, "instance",

--- a/addon.cc
+++ b/addon.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 MNX Cloud, Inc.
+ * Copyright 2024 MNX Cloud, Inc.
  */
 
 /*

--- a/kstat.c
+++ b/kstat.c
@@ -163,8 +163,8 @@ kstatjs_parsearg_int(const nvlist_t *arg, const char *str, int *p)
  * This function consumes its "args" nvlist.
  */
 static int
-kstatjs_parsearg(const nvlist_t *args, char **modulep,
-    char **classp, char **namep, int *instancep)
+kstatjs_parsearg(nvlist_t *args, char **modulep, char **classp, char **namep,
+    int *instancep)
 {
 	int rc = 0;
 	*modulep = *classp = *namep = NULL;

--- a/kstat.c
+++ b/kstat.c
@@ -159,23 +159,27 @@ kstatjs_parsearg_int(const nvlist_t *arg, const char *str, int *p)
 	return (0);
 }
 
+/*
+ * This function consumes its "args" nvlist.
+ */
 static int
 kstatjs_parsearg(const nvlist_t *args, char **modulep,
     char **classp, char **namep, int *instancep)
 {
+	int rc = 0;
 	*modulep = *classp = *namep = NULL;
 	*instancep = -1;
 
 	if (kstatjs_parsearg_string(args, "module", modulep) != 0 ||
 	    kstatjs_parsearg_string(args, "class", classp) != 0 ||
-	    kstatjs_parsearg_string(args, "name", namep) != 0) {
-		return (-1);
+	    kstatjs_parsearg_string(args, "name", namep) != 0 ||
+	    kstatjs_parsearg_int(args, "instance", instancep) != 0) {
+		rc = -1;
 	}
 
-	if (kstatjs_parsearg_int(args, "instance", instancep) != 0)
-		return (-1);
-
-	return (0);
+	/* No caller uses "args" after it's done here. */
+	nvlist_free(args);
+	return (rc);
 }
 
 kstatjs_t *

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kstat",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "illumos libkstat bindings",
   "homepage": "https://github.com/TritonDataCenter/node-kstat",
   "bugs": "https://github.com/TritonDataCenter/node-kstat/issues",


### PR DESCRIPTION
Needs more testing, but putting it up here now for review!

Biggest concern I have is that freeing these nvlists (as they should be freed) might kneecap something else that makes bad assumptions about nvlist content.